### PR TITLE
Tldraw arrow label fix editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -1338,7 +1338,7 @@ const TldrawCanvas = ({ title }: Props) => {
   display: none;
 }
 .rs-arrow-label__inner{
-  flex-direction: column;
+  min-width: initial;
 }${
         maximized
           ? "div.roam-body div.roam-app div.roam-main div.roam-article { position: inherit; }"


### PR DESCRIPTION
When editing label was still broken.

This was the real problem:

![image](https://github.com/RoamJS/query-builder/assets/3792666/249a8990-dc31-4035-aaa2-0b51964bb608)
