### PR TITLE
Add data-column-title to results view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -294,7 +294,8 @@ const ResultRow = ({
               className={"relative overflow-hidden text-ellipsis"}
               key={key}
               {...{
-                [`data-cell-${key}`]: typeof val === "string" ? val : `${val}`,
+                [`data-cell-content`]: typeof val === "string" ? val : `${val}`,
+                [`data-column-title`]: key,
               }}
             >
               {val === "" ? (


### PR DESCRIPTION
added `data-column-title` to target specific columns
changed `data-cell-{key}` to `data-cell-content` to target specific content patterns across all columns