### PR TITLE
add "send to canvas" on export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.10.9",
+  "version": "1.10.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.10.9",
+      "version": "1.10.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.10.9",
+  "version": "1.10.10",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -69,7 +69,6 @@ const ExportProgress = ({ id }: { id: string }) => {
 export type ExportDialogProps = {
   results?: Result[] | ((isSamePageEnabled: boolean) => Promise<Result[]>);
   parentUid: string;
-  clearOnClick?: (text: string) => void;
 };
 
 type ExportDialogComponent = (
@@ -90,7 +89,6 @@ const ExportDialog: ExportDialogComponent = ({
   isOpen,
   results = [],
   parentUid,
-  clearOnClick,
 }) => {
   const exportId = useMemo(() => nanoid(), []);
   useEffect(() => {
@@ -201,7 +199,7 @@ const ExportDialog: ExportDialogComponent = ({
         tldraw[newShapeId] = newShape;
       });
     }
-
+    const newStateId = nanoid();
     window.roamAlphaAPI.updateBlock({
       block: {
         uid: selectedPageUid,
@@ -209,6 +207,7 @@ const ExportDialog: ExportDialogComponent = ({
           ...props,
           ["roamjs-query-builder"]: {
             ...rjsqb,
+            stateId: newStateId,
           },
         },
       },
@@ -229,45 +228,9 @@ const ExportDialog: ExportDialogComponent = ({
     }
   };
 
-  // TODO remove addToCurrentCanvas and addToCurrentPage
-  // Just use addToSelectedCanvas and addToSelectedPage
-
-  const addToCurrentCanvas = () => {
-    if (typeof results === "object") {
-      results.map((r) => {
-        document.dispatchEvent(
-          new CustomEvent("roamjs:query-builder:action", {
-            detail: {
-              action: "canvas",
-              uid: r.uid,
-              val: r.text,
-              queryUid: parentUid,
-            },
-          })
-        );
-      });
-    }
-  };
-
-  const addToCurrentPage = () => {
-    // TODO deal with DNP
-    if (typeof results === "object") {
-      results.map((r) => {
-        clearOnClick?.(r.text || "");
-      });
-    }
-  };
-
   const handleSendTo = () => {
-    const isCurrentPage = selectedPageUid === currentPageUid;
-    const isLocal = typeof results === "object";
-    if (isCurrentPage && isLocal) {
-      isCanvasPage ? addToCurrentCanvas() : addToCurrentPage();
-    } else {
-      isCanvasPage ? addToSelectedCanvas() : addToSelectedPage();
-    }
-
-    setDialogOpen(false);
+    isCanvasPage ? addToSelectedCanvas() : addToSelectedPage();
+    onClose();
   };
 
   const ExportPanel = (

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -26,14 +26,14 @@ import apiPost from "roamjs-components/util/apiPost";
 import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import extensionAPI from "roamjs-components/util/extensionApiContext";
-import { DEFAULT_CANVAS_PAGE_FORMAT } from "../index";
 import getBlockProps from "../utils/getBlockProps";
-import { createShapeId } from "@tldraw/tlschema";
-import { defaultDiscourseNodeShapeProps } from "./TldrawCanvas";
 import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
 import getAllPageNames from "roamjs-components/queries/getAllPageNames";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import findDiscourseNode from "../utils/findDiscourseNode";
+import { DEFAULT_CANVAS_PAGE_FORMAT } from "../index";
+import { createShapeId } from "@tldraw/tlschema";
+import { defaultDiscourseNodeShapeProps } from "./TldrawCanvas";
 
 const ExportProgress = ({ id }: { id: string }) => {
   const [progress, setProgress] = useState(0);
@@ -88,7 +88,6 @@ const ExportDialog: ExportDialogComponent = ({
   onClose,
   isOpen,
   results = [],
-  parentUid,
 }) => {
   const exportId = useMemo(() => nanoid(), []);
   useEffect(() => {
@@ -129,12 +128,12 @@ const ExportDialog: ExportDialogComponent = ({
   const currentPageTitle = getPageTitleByPageUid(currentPageUid);
   const [selectedPageTitle, setSelectedPageTitle] = useState(currentPageTitle);
   const [selectedPageUid, setSelectedPageUid] = useState(currentPageUid);
+  const isCanvasPage = checkForCanvasPage(selectedPageTitle);
 
   const handleSetSelectedPage = (title: string) => {
     setSelectedPageTitle(title);
     setSelectedPageUid(getPageUidByPageTitle(title));
   };
-  const isCanvasPage = checkForCanvasPage(selectedPageTitle);
 
   const addToSelectedCanvas = () => {
     const props = getBlockProps(selectedPageUid) as Record<string, unknown>;
@@ -157,7 +156,6 @@ const ExportDialog: ExportDialogComponent = ({
 
     // TEMP height calc
     // should be using app.textmeasure.MeasureText() like in TldrawCanvas
-
     const calculateHeightAndWidth = (text: String) => {
       const maxWidthNum = 400;
       const paddingNum = 16;
@@ -167,7 +165,6 @@ const ExportDialog: ExportDialogComponent = ({
       const totalCharCount = text.length;
       const totalLines = Math.ceil(totalCharCount / charsPerLine);
       const calculatedHeight = totalLines * (fontSize + 2) + paddingNum * 2;
-
       return { w: maxWidthNum, h: calculatedHeight };
     };
 
@@ -215,7 +212,6 @@ const ExportDialog: ExportDialogComponent = ({
   };
 
   const addToSelectedPage = () => {
-    // TODO: check if page or block
     if (typeof results === "object") {
       results.map((r) => {
         const isPage = !!getPageTitleByPageUid(r.uid);
@@ -377,6 +373,7 @@ const ExportDialog: ExportDialogComponent = ({
       </div>
     </>
   );
+
   const SendToPanel = (
     <>
       <div className={Classes.DIALOG_BODY}>

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -218,10 +218,11 @@ const ExportDialog: ExportDialogComponent = ({
     // TODO: check if page or block
     if (typeof results === "object") {
       results.map((r) => {
+        const isPage = !!getPageTitleByPageUid(r.uid);
         window.roamAlphaAPI.data.block.create({
           location: { "parent-uid": selectedPageUid, order: "last" },
           block: {
-            string: `[[${r.text}]]`,
+            string: isPage ? `[[${r.text}]]` : `((${r.uid}))`,
           },
         });
       });

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -163,9 +163,9 @@ const ExportDialog: ExportDialogComponent = ({
     const calculateHeightAndWidth = (text: String) => {
       const maxWidthNum = 400;
       const paddingNum = 16;
-      const avgCharPixels = 14;
+      const avgCharWidth = 14;
       const fontSize = 24;
-      const charsPerLine = maxWidthNum / avgCharPixels;
+      const charsPerLine = maxWidthNum / avgCharWidth;
       const totalCharCount = text.length;
       const totalLines = Math.ceil(totalCharCount / charsPerLine);
       const calculatedHeight = totalLines * (fontSize + 2) + paddingNum * 2;
@@ -185,7 +185,10 @@ const ExportDialog: ExportDialogComponent = ({
           props: {
             opacity: defaultDiscourseNodeShapeProps.opacity,
             w,
-            h,
+            h:
+              defaultDiscourseNodeShapeProps.h > h
+                ? defaultDiscourseNodeShapeProps.h
+                : h,
             uid: r.uid,
             title: r.text,
           },
@@ -440,20 +443,6 @@ const ExportDialog: ExportDialogComponent = ({
             "Not Yet Supported"
           )}
         </p>
-        {/* <p>
-          selectedPageUid: <span className="font-bold">{selectedPageUid}</span>
-        </p>
-        <p>
-          selectedPageTitle:{" "}
-          <span className="font-bold">{selectedPageTitle}</span>
-        </p>
-        <p>
-          currentPageUid: <span className="font-bold">{currentPageUid}</span>
-        </p>
-        <p>
-          currentPageTitle:{" "}
-          <span className="font-bold">{currentPageTitle}</span>
-        </p> */}
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
@@ -465,13 +454,6 @@ const ExportDialog: ExportDialogComponent = ({
             style={{ minWidth: 64 }}
             disabled={loading}
           />
-          {/* <Button
-            text={"TEMP Log"}
-            intent={Intent.PRIMARY}
-            onClick={tempLogResults}
-            style={{ minWidth: 64 }}
-            disabled={loading}
-          /> */}
         </div>
       </div>
     </>

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -24,7 +24,6 @@ import Export from "./Export";
 
 type Props = {
   blockUid: string;
-  clearOnClick: (s: string) => void;
   onloadArgs: OnloadArgs;
 };
 
@@ -32,7 +31,6 @@ const SavedQuery = ({
   uid,
   isSavedToPage = false,
   onDelete,
-  clearOnClick,
   editSavedQuery,
   initialResults,
   initialColumns,
@@ -40,7 +38,6 @@ const SavedQuery = ({
   uid: string;
   onDelete?: () => void;
   isSavedToPage?: boolean;
-  clearOnClick: (s: string) => void;
   editSavedQuery: (s: string) => void;
   initialResults?: Result[];
   initialColumns?: Column[];
@@ -53,6 +50,9 @@ const SavedQuery = ({
   const [isEditingLabel, setIsEditingLabel] = useState(false);
   const [error, setError] = useState("");
   const [isExportOpen, setIsExportOpen] = useState(false);
+  const toggleExport = (isOpen: boolean) => {
+    setIsExportOpen(isOpen);
+  };
   const resultsInViewRef = useRef<Result[]>([]);
   const refresh = useCallback(() => {
     const args = parseQuery(uid);
@@ -77,14 +77,9 @@ const SavedQuery = ({
         margin: 4,
       }}
     >
-      <Export
-        isOpen={isExportOpen}
-        onClose={() => setIsExportOpen(false)}
-        results={results.map(({ id, ...a }) => a)}
-        parentUid={uid}
-        clearOnClick={clearOnClick}
-      />
       <ResultsView
+        exportIsOpen={isExportOpen}
+        toggleExport={toggleExport}
         parentUid={uid}
         onRefresh={refresh}
         header={
@@ -237,12 +232,10 @@ type SavedQuery = {
 const SavedQueriesContainer = ({
   savedQueries,
   setSavedQueries,
-  clearOnClick,
   setQuery,
 }: {
   savedQueries: SavedQuery[];
   setSavedQueries: (s: SavedQuery[]) => void;
-  clearOnClick: (s: string) => void;
   setQuery: (s: string) => void;
 }) => {
   return (
@@ -253,7 +246,6 @@ const SavedQueriesContainer = ({
         <SavedQuery
           uid={sq.uid}
           key={sq.uid}
-          clearOnClick={clearOnClick}
           onDelete={() => {
             setSavedQueries(savedQueries.filter((s) => s !== sq));
             deleteBlock(sq.uid);
@@ -268,7 +260,6 @@ const SavedQueriesContainer = ({
 };
 
 const QueryDrawerContent = ({
-  clearOnClick,
   blockUid,
   onloadArgs,
   ...exportRenderProps
@@ -351,7 +342,6 @@ const QueryDrawerContent = ({
           <SavedQueriesContainer
             savedQueries={savedQueries}
             setSavedQueries={setSavedQueries}
-            clearOnClick={clearOnClick}
             setQuery={setQuery}
             {...exportRenderProps}
           />

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -20,6 +20,7 @@ import ResultsView from "./ResultsView";
 import ExtensionApiContextProvider from "roamjs-components/components/ExtensionApiContext";
 import QueryEditor from "./QueryEditor";
 import { Column } from "../utils/types";
+import Export from "./Export";
 
 type Props = {
   blockUid: string;
@@ -51,6 +52,7 @@ const SavedQuery = ({
   const [label, setLabel] = useState(() => getTextByBlockUid(uid));
   const [isEditingLabel, setIsEditingLabel] = useState(false);
   const [error, setError] = useState("");
+  const [isExportOpen, setIsExportOpen] = useState(false);
   const resultsInViewRef = useRef<Result[]>([]);
   const refresh = useCallback(() => {
     const args = parseQuery(uid);
@@ -75,6 +77,13 @@ const SavedQuery = ({
         margin: 4,
       }}
     >
+      <Export
+        isOpen={isExportOpen}
+        onClose={() => setIsExportOpen(false)}
+        results={results.map(({ id, ...a }) => a)}
+        parentUid={uid}
+        clearOnClick={clearOnClick}
+      />
       <ResultsView
         parentUid={uid}
         onRefresh={refresh}
@@ -118,9 +127,11 @@ const SavedQuery = ({
                         icon={"insert"}
                         minimal
                         onClick={() => {
-                          resultsInViewRef.current.map((r) => {
-                            clearOnClick?.(r.text || "");
-                          });
+                          if (!initialQuery && minimized) {
+                            setInitialQuery(true);
+                            refresh().finally(() => setMinimized(false));
+                          }
+                          setIsExportOpen(true);
                         }}
                       />
                     </Tooltip>

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -378,6 +378,7 @@ const ResultsView: ResultsViewComponent = ({
         isOpen={isExportOpen}
         onClose={() => setIsExportOpen(false)}
         results={allProcessedResults}
+        parentUid={parentUid}
       />
       <div className="relative">
         <span

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -221,6 +221,8 @@ type ResultsViewComponent = (props: {
   globalFiltersData?: Record<string, Filters>;
   globalPageSize?: number;
   isEditBlock?: boolean;
+  exportIsOpen?: boolean;
+  toggleExport?: (isOpen: boolean) => void;
   // @deprecated - should be inferred from the query or layout
   onResultsInViewChange?: (r: Result[]) => void;
 }) => JSX.Element;
@@ -239,6 +241,8 @@ const ResultsView: ResultsViewComponent = ({
   onRefresh,
   onResultsInViewChange,
   isEditBlock,
+  exportIsOpen = false,
+  toggleExport,
 }) => {
   const extensionAPI = useExtensionAPI();
   const settings = useMemo(
@@ -289,6 +293,15 @@ const ResultsView: ResultsViewComponent = ({
   const [moreMenuOpen, setMoreMenuOpen] = useState(false);
   const [isEditViews, setIsEditViews] = useState(false);
   const [isExportOpen, setIsExportOpen] = useState(false);
+  useEffect(() => {
+    setIsExportOpen(exportIsOpen);
+  }, [exportIsOpen]);
+  const handleCloseExport = () => {
+    if (toggleExport) {
+      toggleExport(false);
+    }
+    setIsExportOpen(false);
+  };
   const [isEditRandom, setIsEditRandom] = useState(false);
   const [isEditLayout, setIsEditLayout] = useState(false);
   const [isEditColumnFilter, setIsEditColumnFilter] = useState(false);
@@ -376,7 +389,7 @@ const ResultsView: ResultsViewComponent = ({
       )}
       <Export
         isOpen={isExportOpen}
-        onClose={() => setIsExportOpen(false)}
+        onClose={handleCloseExport}
         results={allProcessedResults}
         parentUid={parentUid}
       />

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -752,7 +752,7 @@ const ResultsView: ResultsViewComponent = ({
                   />
                   <MenuItem
                     icon={"export"}
-                    text={"Export"}
+                    text={"Export/Send To"}
                     onClick={async () => {
                       if (!results.length) {
                         onRefresh();

--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -463,6 +463,11 @@ const DEFAULT_STYLE_PROPS = {
   padding: "16px",
 };
 
+export const defaultDiscourseNodeShapeProps = {
+  opacity: "1" as DiscourseNodeShape["props"]["opacity"],
+  w: 160,
+  h: 64,
+};
 class DiscourseNodeUtil extends TLBoxUtil<DiscourseNodeShape> {
   constructor(app: TldrawApp, type: string) {
     super(app, type);
@@ -475,9 +480,7 @@ class DiscourseNodeUtil extends TLBoxUtil<DiscourseNodeShape> {
 
   override defaultProps(): DiscourseNodeShape["props"] {
     return {
-      opacity: "1",
-      w: 160,
-      h: 64,
+      ...defaultDiscourseNodeShapeProps,
       uid: window.roamAlphaAPI.util.generateUID(),
       title: "",
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,11 @@ svg.rs-svg-container {
   padding: 16px;
   max-height: 240px;
   overflow-y: scroll;
+}
+
+.roamjs-export-dialog-body .bp3-tab-list {
+  padding: 10px 20px;
+  border-bottom: 1px solid rgba(16,22,26,0.15);
 }`);
   const isCanvasPage = (title: string) => {
     const canvasPageFormat =

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const loadedElsewhere = document.currentScript
   ? document.currentScript.getAttribute("data-source") === "discourse-graph"
   : false;
 
-const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
+export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
   const { extensionAPI } = onloadArgs;


### PR DESCRIPTION
- [x] Send To Canvas, if current page = canvas (via `roamjs:query-builder:action`)
- [x] Send To Page, if current page = page (via `clearOnClick`)
- [x] Add ability to send to specific canvas
- [x] Add ability to send to specific page
- [-] Remove "Insert Results" from header

Customer wanted to keep it there, so instead
- [x] "Insert Results" opens Export dialog

What's left
- [x] `addToSelectedCanvas`: detect what type of node the result is, add that type to canvas
- [x] `addToSelectedPage`: detect what type of node the result is, if block, add ref to page
- [x] support dnp as current (actually, this might work already: test it)
- [x] remove duplicate `<Export>` in `QueryDrawer.tsx`
- [x] remove console logs / clean up

Also, blueprint is handling setting shown tabs/panel, might need to make that controlled by us because `Export Discourse Graph` shows `Send To` as first panel.