### PR TITLE
comment out useEffect to set EditLabelOpen

### DIFF
--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -631,9 +631,9 @@ class DiscourseNodeUtil extends TLBoxUtil<DiscourseNodeShape> {
       [this.app, shape.id]
     );
     const [isLabelEditOpen, setIsEditLabelOpen] = useState(false);
-    useEffect(() => {
-      if (isEditing) setIsEditLabelOpen(true);
-    }, [isEditing, setIsEditLabelOpen]);
+    // useEffect(() => {
+    //   if (isEditing) setIsEditLabelOpen(true);
+    // }, [isEditing, setIsEditLabelOpen]);
     const contentRef = useRef<HTMLDivElement>(null);
     const [loaded, setLoaded] = useState("");
     useEffect(() => {


### PR DESCRIPTION
User was experiencing severe UX issues when adding a node
  - dialog box popup up multiple times
  - multiple nodes being added

Looks like these lines are partially to blame.  Removing them removes the issue, but also removes ability to edit a node. 

Merging thing to give user required functionality.  Will loop back to see what a proper fix would look like.

They were added in #72 .  Let me know if removing these would cause any other breaking changes @dvargas92495 