### PR TITLE
Canvas add/edit node dialog fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.10.5",
+      "version": "1.10.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -631,9 +631,9 @@ class DiscourseNodeUtil extends TLBoxUtil<DiscourseNodeShape> {
       [this.app, shape.id]
     );
     const [isLabelEditOpen, setIsEditLabelOpen] = useState(false);
-    // useEffect(() => {
-    //   if (isEditing) setIsEditLabelOpen(true);
-    // }, [isEditing, setIsEditLabelOpen]);
+    useEffect(() => {
+      if (isEditing) setIsEditLabelOpen(true);
+    }, [isEditing, setIsEditLabelOpen]);
     const contentRef = useRef<HTMLDivElement>(null);
     const [loaded, setLoaded] = useState("");
     useEffect(() => {
@@ -734,6 +734,8 @@ class DiscourseNodeUtil extends TLBoxUtil<DiscourseNodeShape> {
                 w,
                 h,
               });
+              setIsEditLabelOpen(false);
+              this.app.setEditingId(null);
               await this.createExistingRelations(shape, {
                 allRecords,
                 relationIds,


### PR DESCRIPTION
looks like `setIsEditLabelOpen(false);` was missing from `onSuccess`