### PR TITLE
add activeSort support for Kanban view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.21.2",
+  "version": "1.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.21.2",
+      "version": "1.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.21.2",
+  "version": "1.22.0",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -151,12 +151,11 @@ const KanbanCard = (card: {
 
                 return (
                   <React.Fragment key={sv}>
-                    {!uid && (
+                    {!uid && card.viewsByColumn[sv].mode === "embed" ? (
                       <div className="col-span-2 text-sm p-2">
                         [block is blank]
                       </div>
-                    )}
-                    {uid && card.viewsByColumn[sv].mode === "embed" ? (
+                    ) : card.viewsByColumn[sv].mode === "embed" ? (
                       <div className="col-span-2 text-sm -ml-4">
                         <BlockEmbed
                           uid={uid}

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -428,7 +428,7 @@ const Kanban = ({
   const { mode: view, value: viewValue } = viewsByColumn[displayKey] || {};
 
   return (
-    <>
+    <div className="relative">
       {showLegend === "Yes" && (
         <div
           className="p-4 w-full"
@@ -448,16 +448,16 @@ const Kanban = ({
       )}
       <div className="flex w-full p-4">
         <div
-          className="gap-2 items-start relative roamjs-kanban-container overflow-x-scroll grid w-full"
+          className="gap-2 items-start relative roamjs-kanban-container overflow-x-scroll flex w-full"
           ref={containerRef}
         >
           {columns.map((col, columnIndex) => {
             return (
               <div
                 key={col}
-                className="p-4 rounded-2xl flex-col gap-2 bg-gray-100 w-48 flex-shrink-0 roamjs-kanban-column"
+                className="p-4 rounded-2xl flex flex-col gap-2 bg-gray-100 flex-shrink-1 roamjs-kanban-column max-w-2xl"
                 data-column={col}
-                style={{ display: "flex" }}
+                style={{ minWidth: "24rem" }}
               >
                 <div
                   className="justify-between items-center mb-4"
@@ -533,58 +533,57 @@ const Kanban = ({
             );
           })}
         </div>
+      </div>
+      <div className="ml-2 absolute bottom-8 right-8">
         {isAdding ? (
-          <div className="w-48 ml-2">
-            <div className="rounded-2xl p-4 bg-gray-100">
-              <AutocompleteInput
-                placeholder="Enter column title..."
-                value={newColumn}
-                setValue={setNewColumn}
-                options={potentialColumns}
+          <div className="rounded-2xl p-4 bg-gray-100 w-48 border border-gray-200 ">
+            <AutocompleteInput
+              placeholder="Enter column title..."
+              value={newColumn}
+              setValue={setNewColumn}
+              options={potentialColumns}
+            />
+            <div
+              className="justify-between items-center mt-2"
+              style={{ display: "flex" }}
+            >
+              <Button
+                intent="primary"
+                text="Add column"
+                className="text-xs"
+                disabled={!newColumn}
+                onClick={() => {
+                  const values = [...columns, newColumn];
+                  setInputSettings({
+                    blockUid: layoutUid,
+                    key: "columns",
+                    values,
+                  });
+                  setColumns(values);
+                  setIsAdding(false);
+                  setNewColumn("");
+                }}
               />
-              <div
-                className="justify-between items-center mt-2"
-                style={{ display: "flex" }}
-              >
-                <Button
-                  intent="primary"
-                  text="Add column"
-                  className="text-xs"
-                  disabled={!newColumn}
-                  onClick={() => {
-                    const values = [...columns, newColumn];
-                    setInputSettings({
-                      blockUid: layoutUid,
-                      key: "columns",
-                      values,
-                    });
-                    setColumns(values);
-                    setIsAdding(false);
-                    setNewColumn("");
-                  }}
-                />
-                <Button
-                  icon={"cross"}
-                  minimal
-                  onClick={() => setIsAdding(false)}
-                />
-              </div>
+              <Button
+                icon={"cross"}
+                minimal
+                onClick={() => setIsAdding(false)}
+              />
             </div>
           </div>
         ) : (
-          <div className="w-fit ml-2">
-            <Tooltip content="Add another column">
-              <div
-                className="rounded-2xl p-4 cursor-pointer bg-gray-100 hover:bg-opacity-25"
+          <Tooltip content="Add another column">
+            <div>
+              <Icon
+                className="rounded-2xl p-4 cursor-pointer border border-gray-200 bg-gray-100 hover:bg-opacity-25"
+                icon={"plus"}
                 onClick={() => setIsAdding(true)}
-              >
-                <Icon icon={"plus"} />
-              </div>
-            </Tooltip>
-          </div>
+              />
+            </div>
+          </Tooltip>
         )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -20,6 +20,7 @@ import extractTag from "roamjs-components/util/extractTag";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getSubTree from "roamjs-components/util/getSubTree";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
+import { Sorts } from "../utils/parseResultSettings";
 
 const zPriority = z.record(z.number().min(0).max(1));
 
@@ -58,6 +59,7 @@ const KanbanCard = (card: {
   $columnKey: string;
   $selectionValues: string[];
   viewsByColumn: ViewsByColumnType;
+  activeSort: Sorts;
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const anyViewIsEmbed = useMemo(
@@ -193,6 +195,7 @@ const Kanban = ({
   resultKeys,
   parentUid,
   views,
+  activeSort,
 }: {
   resultKeys: Column[];
   data: Result[];
@@ -200,6 +203,7 @@ const Kanban = ({
   onQuery: () => void;
   parentUid: string;
   views: { column: string; mode: string; value: string }[];
+  activeSort: Sorts;
 }) => {
   const byUid = useMemo(
     () => Object.fromEntries(data.map((d) => [d.uid, d] as const)),
@@ -314,6 +318,7 @@ const Kanban = ({
       }
       cards[column].push(d);
     });
+    if (activeSort.length) return cards;
     Object.keys(cards).forEach((k) => {
       cards[k] = cards[k].sort(
         (a, b) => prioritization[a.uid] - prioritization[b.uid]
@@ -541,6 +546,7 @@ const Kanban = ({
                     key={d.uid}
                     result={d}
                     viewsByColumn={viewsByColumn}
+                    activeSort={activeSort}
                     // we use $ to prefix these props to avoid collisions with the result object
                     $priority={prioritization[d.uid]}
                     $reprioritize={reprioritizeAndUpdateBlock}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -1155,6 +1155,7 @@ const ResultsView: ResultsViewComponent = ({
                   resultKeys={columns}
                   parentUid={parentUid}
                   views={views}
+                  activeSort={activeSort}
                 />
               ) : (
                 <div style={{ padding: "16px 8px" }}>

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -469,6 +469,7 @@ const ResultsView: ResultsViewComponent = ({
               setIsEditLayout(false);
               setIsEditColumnFilter(false);
               setIsEditViews(false);
+              setIsEditColumnSort(false);
             }}
             autoFocus={false}
             enforceFocus={false}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -1156,6 +1156,7 @@ const ResultsView: ResultsViewComponent = ({
                   parentUid={parentUid}
                   views={views}
                   activeSort={activeSort}
+                  setActiveSort={resultViewSetActiveSort}
                 />
               ) : (
                 <div style={{ padding: "16px 8px" }}>

--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -1552,6 +1552,15 @@ const TldrawCanvas = ({ title }: Props) => {
       }
       #roamjs-tldraw-canvas-container .rs-shape .roamjs-tldraw-node .rm-block-main .rm-block-separator {
         display: none;
+      }
+      /* arrow label line fix */
+      /* seems like width is being miscalculted cause letters to linebreak */
+      /* TODO: this is a temporary fix */
+      /* also Roam is hijacking the font choice */
+      .rs-arrow-label .rs-arrow-label__inner p {
+        padding: 0;
+        white-space: nowrap;
+        font-family: var(--rs-font-sans);
       }`}
       </style>
       <TldrawEditor

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,15 +160,13 @@ svg.rs-svg-container {
   z-index: 1000;
 }
 
-.roamjs-kanban-container .react-draggable.roamjs-kanban-card > div {
-  transform: rotate(0deg);
-  cursor: pointer;
-}
-
 .roamjs-kanban-container .roamjs-kanban-column {
   width: inherit;
 }
 
+.roamjs-kanban-container .roamjs-kanban-column .rm-block-separator {
+  display:none;
+}
 .roamjs-extra-row td {
   position: relative;
   background-color: #F5F8FA;

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,10 +165,6 @@ svg.rs-svg-container {
   cursor: pointer;
 }
 
-.roamjs-kanban-container {
-  grid-template-columns: repeat(auto-fit, minmax(10%, 1fr));
-}
-
 .roamjs-kanban-container .roamjs-kanban-column {
   width: inherit;
 }

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -1,0 +1,49 @@
+// To be removed when format is migrated to specification
+// https://github.com/RoamJS/query-builder/issues/189
+
+import { PullBlock } from "roamjs-components/types";
+import getDiscourseNodes from "../utils/getDiscourseNodes";
+import compileDatalog from "./compileDatalog";
+import discourseNodeFormatToDatalog from "./discourseNodeFormatToDatalog";
+
+export const getNewDiscourseNodeText = ({
+  text,
+  nodeType,
+  blockUid,
+}: {
+  text: string;
+  nodeType: string;
+  blockUid?: string;
+}) => {
+  const discourseNodes = getDiscourseNodes().filter(
+    (n) => n.backedBy === "user"
+  );
+  const indexedByType = Object.fromEntries(
+    discourseNodes.map((mi, i) => [mi.type, mi])
+  );
+
+  const format = indexedByType[nodeType]?.format || "";
+  const newText = format.replace(/{([\w\d-]*)}/g, (_, val) => {
+    if (/content/i.test(val)) return text;
+    const referencedNode = discourseNodes.find(({ text }) =>
+      new RegExp(text, "i").test(val)
+    );
+    if (referencedNode) {
+      const referenced = window.roamAlphaAPI.data.fast.q(
+        `[:find (pull ?r [:node/title :block/string]) :where [?b :block/uid "${blockUid}"] (or-join [?b ?r] (and [?b :block/parents ?p] [?p :block/refs ?r]) (and [?b :block/page ?r])) ${discourseNodeFormatToDatalog(
+          {
+            freeVar: "r",
+            ...referencedNode,
+          }
+        )
+          .map((c) => compileDatalog(c, 0))
+          .join(" ")}]`
+      )?.[0]?.[0] as PullBlock;
+      return referenced?.[":node/title"]
+        ? `[[${referenced?.[":node/title"]}]]`
+        : referenced?.[":block/string"] || "";
+    }
+    return "";
+  });
+  return newText;
+};


### PR DESCRIPTION
I'm unsure how we should handle dragging when `activeSort` is set.

Use cases:

Drag to new column to change attribute
 - my intuition says that `activeSort` should be maintained

Drag to reposition in same column
 - currently not supported, `activeSort` is maintained
 - [x] probably should remove `activeSort` and create a new prioritization based on where cards currently are + moved card.
