### PR TITLE
Fix arrow label line break issue and font choice hijacking

### DIFF
--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -1552,6 +1552,15 @@ const TldrawCanvas = ({ title }: Props) => {
       }
       #roamjs-tldraw-canvas-container .rs-shape .roamjs-tldraw-node .rm-block-main .rm-block-separator {
         display: none;
+      }
+      /* arrow label line fix */
+      /* seems like width is being miscalculted cause letters to linebreak */
+      /* TODO: this is a temporary fix */
+      /* also Roam is hijacking the font choice */
+      .rs-arrow-label .rs-arrow-label__inner p {
+        padding: 0;
+        white-space: nowrap;
+        font-family: var(--rs-font-sans);
       }`}
       </style>
       <TldrawEditor


### PR DESCRIPTION
This pull request fixes the issue with arrow label line breaks and font choice hijacking in the TldrawCanvas component. The width calculation was causing the letters to line break, and Roam was hijacking the font choice. This PR includes a temporary fix by adding padding, setting white-space to nowrap, and specifying the font-family as var(--rs-font-sans) for the rs-arrow-label class.

☝ yay AI ✨