### PR TITLE
Optimize Discourse Export

### DIFF
--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -143,17 +143,11 @@ const ExportDialog: ExportDialogComponent = ({
   useEffect(() => {
     if (isExportDiscourseGraph) setSelectedTabId("export");
   }, [isExportDiscourseGraph]);
-  const getDiscourseGraphSetting = () =>
-    getExtensionAPI().settings.get("discourse-graphs");
-  const [discourseGraphSetting, setDiscourseGraphSetting] = useState(
-    getDiscourseGraphSetting()
-  );
-  const discourseGraphEnabled = useMemo(
-    () => discourseGraphSetting,
-    [discourseGraphSetting]
-  );
+  const [discourseGraphEnabled, setDiscourseGraphEnabled] = useState(() => {
+    return getExtensionAPI().settings.get("discourse-graphs");
+  });
   const [includeDiscourseContext, setIncludeDiscourseContext] = useState(
-    discourseGraphSetting as boolean
+    discourseGraphEnabled as boolean
   );
   const handleSetSelectedPage = (title: string) => {
     setSelectedPageTitle(title);

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -14,6 +14,7 @@ import {
   Tabs,
   RadioGroup,
   Radio,
+  FormGroup,
 } from "@blueprintjs/core";
 import React, { useState, useEffect, useMemo } from "react";
 import MenuItemSelect from "roamjs-components/components/MenuItemSelect";
@@ -136,7 +137,18 @@ const ExportDialog: ExportDialogComponent = ({
   const isCanvasPage = checkForCanvasPage(selectedPageTitle);
   const [isSendToGraph, setIsSendToGraph] = useState(false);
   const [livePages, setLivePages] = useState<Result[]>([]);
-
+  const getDiscourseGraphSetting = () =>
+    getExtensionAPI().settings.get("discourse-graphs");
+  const [discourseGraphSetting, setDiscourseGraphSetting] = useState(
+    getDiscourseGraphSetting()
+  );
+  const discourseGraphEnabled = useMemo(
+    () => discourseGraphSetting,
+    [discourseGraphSetting]
+  );
+  const [includeDiscourseContext, setIncludeDiscourseContext] = useState(
+    discourseGraphSetting as boolean
+  );
   const handleSetSelectedPage = (title: string) => {
     setSelectedPageTitle(title);
     setSelectedPageUid(getPageUidByPageTitle(title));
@@ -282,7 +294,24 @@ const ExportDialog: ExportDialogComponent = ({
             onChange={(e) => setFilename(e.target.value)}
           />
         </Label>
-        <div className="flex justify-between items-center">
+        <FormGroup
+          className={discourseGraphEnabled ? "" : "hidden"}
+          label="Include Discourse Context"
+          inline
+        >
+          <Checkbox
+            checked={includeDiscourseContext}
+            onChange={(e) => {
+              setIncludeDiscourseContext(
+                (e.target as HTMLInputElement).checked
+              );
+              console.log(
+                (e.target as HTMLInputElement).checked ? "true" : "false"
+              );
+            }}
+          />
+        </FormGroup>
+        <div className="text-right">
           <span>
             {typeof results === "function"
               ? "Calculating number of results..."
@@ -347,6 +376,7 @@ const ExportDialog: ExportDialogComponent = ({
                     const files = await exportType.callback({
                       filename,
                       isSamePageEnabled,
+                      includeDiscourseContext,
                     });
                     if (!files.length) {
                       setDialogOpen(true);

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -103,7 +103,7 @@ const ExportDialog: ExportDialogComponent = ({
   }, [isOpen]);
   const [dialogOpen, setDialogOpen] = useState(isOpen);
   const exportTypes = useMemo(
-    () => getExportTypes({ results, exportId }),
+    () => getExportTypes({ results, exportId, isExportDiscourseGraph }),
     [results, exportId]
   );
   const [loading, setLoading] = useState(false);
@@ -391,6 +391,7 @@ const ExportDialog: ExportDialogComponent = ({
                       filename,
                       isSamePageEnabled,
                       includeDiscourseContext,
+                      isExportDiscourseGraph,
                     });
                     if (!files.length) {
                       setDialogOpen(true);

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -74,6 +74,7 @@ const ExportProgress = ({ id }: { id: string }) => {
 export type ExportDialogProps = {
   results?: Result[] | ((isSamePageEnabled: boolean) => Promise<Result[]>);
   title?: string;
+  isExportDiscourseGraph?: boolean;
 };
 
 type ExportDialogComponent = (
@@ -94,6 +95,7 @@ const ExportDialog: ExportDialogComponent = ({
   isOpen,
   results = [],
   title = "Share Data",
+  isExportDiscourseGraph = false,
 }) => {
   const exportId = useMemo(() => nanoid(), []);
   useEffect(() => {
@@ -137,6 +139,10 @@ const ExportDialog: ExportDialogComponent = ({
   const isCanvasPage = checkForCanvasPage(selectedPageTitle);
   const [isSendToGraph, setIsSendToGraph] = useState(false);
   const [livePages, setLivePages] = useState<Result[]>([]);
+  const [selectedTabId, setSelectedTabId] = useState("sendto");
+  useEffect(() => {
+    if (isExportDiscourseGraph) setSelectedTabId("export");
+  }, [isExportDiscourseGraph]);
   const getDiscourseGraphSetting = () =>
     getExtensionAPI().settings.get("discourse-graphs");
   const [discourseGraphSetting, setDiscourseGraphSetting] = useState(
@@ -294,48 +300,65 @@ const ExportDialog: ExportDialogComponent = ({
             onChange={(e) => setFilename(e.target.value)}
           />
         </Label>
-        <FormGroup
-          className={discourseGraphEnabled ? "" : "hidden"}
-          label="Include Discourse Context"
-          inline
-        >
-          <Checkbox
-            checked={includeDiscourseContext}
-            onChange={(e) => {
-              setIncludeDiscourseContext(
-                (e.target as HTMLInputElement).checked
-              );
-            }}
-          />
-        </FormGroup>
-        <div className="text-right">
+
+        <div className="flex justify-between items-end">
           <span>
             {typeof results === "function"
               ? "Calculating number of results..."
               : `Exporting ${results.length} results`}
           </span>
-          {window.samepage && (
-            <Checkbox
-              checked={isSamePageEnabled}
-              onChange={(e) =>
-                setIsSamePageEnabled((e.target as HTMLInputElement).checked)
-              }
-              style={{ marginBottom: 0 }}
-              labelElement={
-                <Tooltip
-                  content={
-                    "Use SamePage's backend to gather this export [EXPERIMENTAL]."
+          <div className="flex flex-col items-end">
+            <FormGroup
+              className={`m-0 ${discourseGraphEnabled ? "" : "hidden"}`}
+              inline
+            >
+              <Checkbox
+                alignIndicator={"right"}
+                checked={includeDiscourseContext}
+                onChange={(e) => {
+                  setIncludeDiscourseContext(
+                    (e.target as HTMLInputElement).checked
+                  );
+                }}
+                labelElement={
+                  <Tooltip
+                    className="m-0"
+                    content={
+                      "Include the Discourse Context of each result in the export."
+                    }
+                  >
+                    <span>Discourse Context</span>
+                  </Tooltip>
+                }
+              />
+            </FormGroup>
+            {window.samepage && (
+              <FormGroup className="m-0 " inline>
+                <Checkbox
+                  alignIndicator={"right"}
+                  checked={isSamePageEnabled}
+                  onChange={(e) =>
+                    setIsSamePageEnabled((e.target as HTMLInputElement).checked)
                   }
-                >
-                  <img
-                    src="https://samepage.network/images/logo.png"
-                    height={24}
-                    width={24}
-                  />
-                </Tooltip>
-              }
-            />
-          )}
+                  style={{ marginBottom: 0 }}
+                  labelElement={
+                    <Tooltip
+                      className="m-0"
+                      content={
+                        "Use SamePage's backend to gather this export [EXPERIMENTAL]."
+                      }
+                    >
+                      <img
+                        src="https://samepage.network/images/logo.png"
+                        height={24}
+                        width={24}
+                      />
+                    </Tooltip>
+                  }
+                />
+              </FormGroup>
+            )}
+          </div>
         </div>
       </div>
       <div className={Classes.DIALOG_FOOTER}>
@@ -479,7 +502,12 @@ const ExportDialog: ExportDialogComponent = ({
         enforceFocus={false}
         portalClassName={"roamjs-export-dialog-body"}
       >
-        <Tabs id="export-tabs" large={true}>
+        <Tabs
+          id="export-tabs"
+          large={true}
+          selectedTabId={selectedTabId}
+          onChange={(newTabId: string) => setSelectedTabId(newTabId)}
+        >
           <Tab id="sendto" title="Send To" panel={SendToPanel} />
           <Tab id="export" title="Export" panel={ExportPanel} />
         </Tabs>

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -305,9 +305,6 @@ const ExportDialog: ExportDialogComponent = ({
               setIncludeDiscourseContext(
                 (e.target as HTMLInputElement).checked
               );
-              console.log(
-                (e.target as HTMLInputElement).checked ? "true" : "false"
-              );
             }}
           />
         </FormGroup>

--- a/src/discourseGraphsMode.ts
+++ b/src/discourseGraphsMode.ts
@@ -54,6 +54,7 @@ import CanvasReferences from "./components/CanvasReferences";
 import fireQuery from "./utils/fireQuery";
 import { render as renderGraphOverviewExport } from "./components/ExportDiscourseContext";
 import { Condition, QBClause } from "./utils/types";
+import { DiscourseExportResult } from "./utils/getExportTypes";
 
 export const SETTING = "discourse-graphs";
 
@@ -874,7 +875,11 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
           const discourseNodes = getDiscourseNodes().filter(
             (r) => r.backedBy !== "default"
           );
-          const results = (isSamePageEnabled: boolean) =>
+          const results: (
+            isSamePageEnabled: boolean
+          ) => Promise<DiscourseExportResult[]> = (
+            isSamePageEnabled: boolean
+          ) =>
             Promise.all(
               discourseNodes.map((d) =>
                 fireQuery({
@@ -890,7 +895,12 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
                   ],
                   selections: [],
                   isSamePageEnabled,
-                })
+                }).then((queryResults) =>
+                  queryResults.map((result) => ({
+                    ...result,
+                    type: d.type,
+                  }))
+                )
               )
             ).then((r) => r.flat());
           exportRender({

--- a/src/discourseGraphsMode.ts
+++ b/src/discourseGraphsMode.ts
@@ -896,6 +896,7 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
           exportRender({
             results,
             title: "Export Discourse Graph",
+            isExportDiscourseGraph: true,
           });
         },
       });

--- a/src/utils/getExportTypes.ts
+++ b/src/utils/getExportTypes.ts
@@ -195,9 +195,16 @@ const toMarkdown = ({
 type Props = {
   results?: ExportDialogProps["results"];
   exportId: string;
+  isExportDiscourseGraph: boolean;
 };
 
-const getExportTypes = ({ results, exportId }: Props): ExportTypes => {
+export type DiscourseExportResult = Result & { type: string };
+
+const getExportTypes = ({
+  results,
+  exportId,
+  isExportDiscourseGraph,
+}: Props): ExportTypes => {
   const allRelations = getDiscourseRelations();
   const allNodes = getDiscourseNodes(allRelations);
   const nodeLabelByType = Object.fromEntries(
@@ -205,12 +212,16 @@ const getExportTypes = ({ results, exportId }: Props): ExportTypes => {
   );
   nodeLabelByType["*"] = "Any";
   const getPageData = async (
-    isSamePageEnabled: boolean
+    isSamePageEnabled: boolean,
+    isExportDiscourseGraph?: boolean
   ): Promise<(Result & { type: string })[]> => {
     const allResults =
       typeof results === "function"
         ? await results(isSamePageEnabled)
-        : results;
+        : results || [];
+
+    if (isExportDiscourseGraph) return allResults as DiscourseExportResult[];
+
     const matchedTexts = new Set();
     return allNodes.flatMap((n) =>
       (allResults
@@ -367,7 +378,10 @@ const getExportTypes = ({ results, exportId }: Props): ExportTypes => {
               `author: {author}`,
               "date: {date}",
             ];
-        const allPages = await getPageData(isSamePageEnabled);
+        const allPages = await getPageData(
+          isSamePageEnabled,
+          isExportDiscourseGraph
+        );
         const gatherings = allPages.map(
           ({ text, uid, context: _, type, ...rest }, i, all) =>
             async function getMarkdownData() {

--- a/src/utils/getExportTypes.ts
+++ b/src/utils/getExportTypes.ts
@@ -200,11 +200,8 @@ type Props = {
 const getExportTypes = ({ results, exportId }: Props): ExportTypes => {
   const allRelations = getDiscourseRelations();
   const allNodes = getDiscourseNodes(allRelations);
-  const allNodesDefaultRemoved = allNodes.filter(
-    (node) => node.backedBy !== "default"
-  );
   const nodeLabelByType = Object.fromEntries(
-    allNodesDefaultRemoved.map((a) => [a.type, a.text])
+    allNodes.map((a) => [a.type, a.text])
   );
   nodeLabelByType["*"] = "Any";
   const getPageData = async (
@@ -215,7 +212,7 @@ const getExportTypes = ({ results, exportId }: Props): ExportTypes => {
         ? await results(isSamePageEnabled)
         : results;
     const matchedTexts = new Set();
-    return allNodesDefaultRemoved.flatMap((n) =>
+    return allNodes.flatMap((n) =>
       (allResults
         ? allResults.flatMap((r) =>
             Object.keys(r)

--- a/src/utils/getExportTypes.ts
+++ b/src/utils/getExportTypes.ts
@@ -311,7 +311,10 @@ const getExportTypes = ({ results, exportId }: Props): ExportTypes => {
   return [
     {
       name: "Markdown",
-      callback: async ({ isSamePageEnabled }) => {
+      callback: async ({
+        isSamePageEnabled,
+        includeDiscourseContext = false,
+      }) => {
         const configTree = getBasicTreeByParentUid(
           getPageUidByPageTitle("roam/js/discourse-graph")
         );
@@ -381,10 +384,12 @@ const getExportTypes = ({ results, exportId }: Props): ExportTypes => {
                 type,
               };
               const treeNode = getFullTreeByParentUid(uid);
-              const discourseResults = await getDiscourseContextResults({
-                uid,
-                isSamePageEnabled,
-              });
+              const discourseResults = includeDiscourseContext
+                ? await getDiscourseContextResults({
+                    uid,
+                    isSamePageEnabled,
+                  })
+                : [];
               const referenceResults = isFlagEnabled("render references")
                 ? (
                     window.roamAlphaAPI.data.fast.q(

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -36,6 +36,7 @@ export type ExportTypes = {
     filename: string;
     isSamePageEnabled: boolean;
     includeDiscourseContext: boolean;
+    isExportDiscourseGraph: boolean;
   }) => Promise<{ title: string; content: string }[]>;
 }[];
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -35,6 +35,7 @@ export type ExportTypes = {
   callback: (args: {
     filename: string;
     isSamePageEnabled: boolean;
+    includeDiscourseContext: boolean;
   }) => Promise<{ title: string; content: string }[]>;
 }[];
 


### PR DESCRIPTION
Just before creating this PR I realized I missed something 😑 (which is the reason for all the comment edits)

I thought I had an epiphany here (see video 😅) but in my dev branch I wasn't accounting for the results being passed by the `Export Discourse Graph` command.  But it turns out even with those results being passed in, because of `block` / `page`, the `gatherings` output gets significantly increased.  (even more than my video shows)

https://www.loom.com/share/664fd3cc2125492cbb16009500b9d0a8

Looks like the `Set` check clears it up.

And I'm curious, @dvargas92495, what is the purpose of the `matchDiscourseNode` filter in `getPageData`? (see comment in review)