### PR TITLE
Refactor predefinedSelections update function

### DIFF
--- a/src/utils/predefinedSelections.ts
+++ b/src/utils/predefinedSelections.ts
@@ -523,10 +523,6 @@ const predefinedSelections: PredefinedSelection[] = [
     },
     update: async ({ uid, value, result, selection, previousValue }) => {
       const blockText = getTextByBlockUid(uid);
-      const oldValue = toCellValue({
-        value: result[selection],
-        uid: result[`${selection}-uid`],
-      });
       if (!uid) {
         createBlock({
           parentUid: result.uid,
@@ -540,7 +536,7 @@ const predefinedSelections: PredefinedSelection[] = [
         uid,
         text: !previousValue
           ? `${selection}:: ${value}`
-          : blockText.replace(oldValue, value),
+          : blockText.replace(previousValue, value),
       });
     },
     suggestions: [], // ATTR_SUGGESTIONS,


### PR DESCRIPTION
from these changes: https://github.com/RoamJS/query-builder/pull/146

`oldValue` wasn't updated to `previousValue` which is:

```javascript
      const previousValue = toCellValue({
        value: result[columnKey],
        uid: columnUid?.toString(),
      });
```
      
If the selection `label` was different than `data` (attribute name), `oldValue` would return `""` and prepend the block with the new value.

eg:
as `status` select `Status`
as `abc` select `Status`