### PR TITLE
handle custom first column name

### DIFF
--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -245,7 +245,7 @@ const ExportDialog: ExportDialogComponent = ({
       const nodeType = discourseNode ? discourseNode.type : "page-node";
       const extensionAPI = getExtensionAPI();
       const { h, w, imageUrl } = await calcCanvasNodeSizeAndImg({
-        text: r[firstColumnKey],
+        nodeText: String(r[firstColumnKey]),
         uid: r.uid,
         nodeType,
         extensionAPI,
@@ -340,7 +340,7 @@ const ExportDialog: ExportDialogComponent = ({
     } catch (e) {
       const error = e as Error;
       renderToast({
-        content: "Looks like there was an error.  The team has been notified.",
+        content: "Looks like there was an error. The team has been notified.",
         intent: "danger",
         id: "query-builder-error",
       });

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -457,6 +457,7 @@ const ResultsView: ResultsViewComponent = ({
         isOpen={isExportOpen}
         onClose={handleCloseExport}
         results={allProcessedResults}
+        columns={columns}
       />
       <div className="relative">
         <div

--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -537,7 +537,7 @@ class DiscourseNodeUtil extends TLBoxUtil<DiscourseNodeShape> {
     }) => {
       if (!extensionAPI) return;
       const { h, w, imageUrl } = await calcCanvasNodeSizeAndImg({
-        text,
+        nodeText: text,
         uid,
         nodeType: this.type,
         extensionAPI,
@@ -1296,7 +1296,7 @@ const TldrawCanvas = ({ title }: Props) => {
                           });
                           const { h, w, imageUrl } =
                             await calcCanvasNodeSizeAndImg({
-                              text: newTitle,
+                              nodeText: newTitle,
                               uid: target.props.uid,
                               nodeType: target.type,
                               extensionAPI,
@@ -1867,7 +1867,7 @@ const TldrawCanvas = ({ title }: Props) => {
                   app.deleteShapes([shape.id]);
                   const { x, y } = shape;
                   const { h, w, imageUrl } = await calcCanvasNodeSizeAndImg({
-                    text: nodeText,
+                    nodeText: nodeText,
                     extensionAPI,
                     nodeType: type,
                     uid,

--- a/src/utils/calcCanvasNodeSizeAndImg.ts
+++ b/src/utils/calcCanvasNodeSizeAndImg.ts
@@ -44,7 +44,7 @@ const calcCanvasNodeSizeAndImg = async ({
   nodeType,
   extensionAPI,
 }: {
-  text: string;
+  text: string | number | Date;
   uid: string;
   nodeType: string;
   extensionAPI: OnloadArgs["extensionAPI"];
@@ -62,7 +62,7 @@ const calcCanvasNodeSizeAndImg = async ({
   const { w, h } = measureCanvasNodeText({
     ...DEFAULT_STYLE_PROPS,
     maxWidth: MAX_WIDTH,
-    text,
+    text: String(text),
   });
 
   if (!isKeyImage) return { w, h, imageUrl: "" };
@@ -76,7 +76,7 @@ const calcCanvasNodeSizeAndImg = async ({
     const results = await runQuery({
       extensionAPI,
       parentUid,
-      inputs: { NODETEXT: text, NODEUID: uid },
+      inputs: { NODETEXT: String(text), NODEUID: uid },
     });
     const result = results.allProcessedResults[0]?.text || "";
     imageUrl = extractFirstImageUrl(result);

--- a/src/utils/calcCanvasNodeSizeAndImg.ts
+++ b/src/utils/calcCanvasNodeSizeAndImg.ts
@@ -39,12 +39,12 @@ const getFirstImageByUid = (uid: string): string | null => {
 };
 
 const calcCanvasNodeSizeAndImg = async ({
-  text,
+  nodeText,
   uid,
   nodeType,
   extensionAPI,
 }: {
-  text: string | number | Date;
+  nodeText: string;
   uid: string;
   nodeType: string;
   extensionAPI: OnloadArgs["extensionAPI"];
@@ -62,7 +62,7 @@ const calcCanvasNodeSizeAndImg = async ({
   const { w, h } = measureCanvasNodeText({
     ...DEFAULT_STYLE_PROPS,
     maxWidth: MAX_WIDTH,
-    text: String(text),
+    text: nodeText,
   });
 
   if (!isKeyImage) return { w, h, imageUrl: "" };
@@ -76,7 +76,7 @@ const calcCanvasNodeSizeAndImg = async ({
     const results = await runQuery({
       extensionAPI,
       parentUid,
-      inputs: { NODETEXT: String(text), NODEUID: uid },
+      inputs: { NODETEXT: nodeText, NODEUID: uid },
     });
     const result = results.allProcessedResults[0]?.text || "";
     imageUrl = extractFirstImageUrl(result);


### PR DESCRIPTION
when the first column is renamed via a `node` selection, `r.text` was undefined in `Share Data` > `Send To`
![image](https://github.com/RoamJS/query-builder/assets/3792666/00949497-1ff0-45c7-b0f2-b66c937227b1)


![image](https://github.com/RoamJS/query-builder/assets/3792666/90d7b51a-7f49-4c29-bd1b-7235f5b65696)
