### PR TITLE
add regex support to 'with text', handle case insensitive regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.27.1",
+      "version": "1.28.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {


### PR DESCRIPTION
- add regex support for `with text`
- add case-insensitive support for regex `with text` and `has title` (`/some text/i`)

![image](https://github.com/RoamJS/query-builder/assets/3792666/12d1f296-45d0-4b4c-83eb-d8dc4dc68eb2)

