### PR TITLE
Add referenced node to exported discourse context

### DIFF
--- a/src/discourseGraphsMode.ts
+++ b/src/discourseGraphsMode.ts
@@ -612,6 +612,13 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
                     items: ["alias", "wikilinks"],
                   },
                 } as Field<SelectField>,
+                {
+                  title: "append referenced node",
+                  // @ts-ignore
+                  Panel: FlagPanel,
+                  description:
+                    "If a referenced node is defined in a node's format, it will be appended to the discourse context",
+                },
               ],
             },
           ],

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -8,6 +8,10 @@ import discourseNodeFormatToDatalog from "./discourseNodeFormatToDatalog";
 import createOverlayRender from "roamjs-components/util/createOverlayRender";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import FormDialog from "roamjs-components/components/FormDialog";
+import { QBClause, Result } from "./types";
+import findDiscourseNode from "./findDiscourseNode";
+import extractTag from "roamjs-components/util/extractTag";
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 
 type FormDialogProps = Parameters<typeof FormDialog>[0];
 const renderFormDialog = createOverlayRender<FormDialogProps>(
@@ -87,12 +91,21 @@ export const getNewDiscourseNodeText = async ({
 };
 
 export const getReferencedNodeInFormat = ({
-  format,
+  uid,
+  format: providedFormat,
   discourseNodes = getDiscourseNodes(),
 }: {
-  format: string;
+  uid?: string;
+  format?: string;
   discourseNodes?: DiscourseNode[];
 }) => {
+  let format = providedFormat;
+  if (!format) {
+    const discourseNode = findDiscourseNode(uid);
+    if (discourseNode) format = discourseNode.format;
+  }
+  if (!format) return null;
+
   const regex = /{([\w\d-]*)}/g;
   const matches = [...format.matchAll(regex)];
 
@@ -108,4 +121,42 @@ export const getReferencedNodeInFormat = ({
   }
 
   return null;
+};
+
+export const findReferencedNodeInText = ({
+  text,
+  discourseNode,
+}: {
+  text: string;
+  discourseNode: DiscourseNode;
+}) => {
+  // assumes that the referenced node in format has a specification
+  // which includes:
+  // has title relation
+  // a (.*?) pattern in it's target
+  // eg: Source: /^@(.*?)$/
+
+  const specification = discourseNode.specification;
+  const titleCondition = specification.find(
+    (s): s is QBClause => s.type === "clause" && s.relation === "has title"
+  );
+  if (!titleCondition) return null;
+
+  // Remove leading and trailing slashes and start/end modifiers
+  const patternStr = titleCondition.target.slice(1, -1).replace(/^\^|\$$/g, "");
+
+  // Since we aummar there's always a (.*?), we replace it with a specific pattern to capture text within [[ ]]
+  // This assumes (.*?) is meant to capture the relevant content
+  const modifiedPatternStr = patternStr.replace(/\(\.\*\?\)/, "(.*?)");
+  const dynamicPattern = new RegExp(`\\[\\[${modifiedPatternStr}\\]\\]`, "g");
+  const match = text.match(dynamicPattern)?.[0] || "";
+  if (!match) return null;
+
+  const pageTitle = extractTag(match);
+  const uid = getPageUidByPageTitle(pageTitle);
+
+  return {
+    uid,
+    text: pageTitle,
+  } as Result;
 };

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -145,7 +145,7 @@ export const findReferencedNodeInText = ({
   // Remove leading and trailing slashes and start/end modifiers
   const patternStr = titleCondition.target.slice(1, -1).replace(/^\^|\$$/g, "");
 
-  // Since we aummar there's always a (.*?), we replace it with a specific pattern to capture text within [[ ]]
+  // Since we assume there's always a (.*?), we replace it with a specific pattern to capture text within [[ ]]
   // This assumes (.*?) is meant to capture the relevant content
   const modifiedPatternStr = patternStr.replace(/\(\.\*\?\)/, "(.*?)");
   const dynamicPattern = new RegExp(`\\[\\[${modifiedPatternStr}\\]\\]`, "g");

--- a/src/utils/getExportTypes.ts
+++ b/src/utils/getExportTypes.ts
@@ -228,13 +228,13 @@ const handleDiscourseContext = async ({
   uid,
   pageTitle,
   isSamePageEnabled,
-  appendReferencedNodeToDiscourseContext,
+  appendRefNodeContext,
 }: {
   includeDiscourseContext: boolean;
   uid: string;
   pageTitle: string;
   isSamePageEnabled: boolean;
-  appendReferencedNodeToDiscourseContext: boolean;
+  appendRefNodeContext: boolean;
 }) => {
   if (!includeDiscourseContext) return [];
 
@@ -242,7 +242,7 @@ const handleDiscourseContext = async ({
     uid,
     isSamePageEnabled,
   });
-  if (!appendReferencedNodeToDiscourseContext) return discourseResults;
+  if (!appendRefNodeContext) return discourseResults;
 
   const referencedDiscourseNode = getReferencedNodeInFormat({ uid });
   if (referencedDiscourseNode) {
@@ -432,6 +432,10 @@ const getExportTypes = ({
       tree: exportTree.children,
       key: "resolve block embeds",
     }).uid;
+    const appendRefNodeContext = !!getSubTree({
+      tree: exportTree.children,
+      key: "append referenced node",
+    }).uid;
     const yaml = frontmatter.length
       ? frontmatter
       : [
@@ -448,6 +452,7 @@ const getExportTypes = ({
       maxFilenameLength,
       removeSpecialCharacters,
       linkType,
+      appendRefNodeContext,
     };
   };
 
@@ -466,6 +471,7 @@ const getExportTypes = ({
           maxFilenameLength,
           removeSpecialCharacters,
           linkType,
+          appendRefNodeContext,
         } = getExportSettings();
         const allPages = await getPageData(
           isSamePageEnabled,
@@ -495,13 +501,12 @@ const getExportTypes = ({
               };
               const treeNode = getFullTreeByParentUid(uid);
 
-              const appendReferencedNodeToDiscourseContext = true; // TODO: make this a setting
               const discourseResults = await handleDiscourseContext({
                 includeDiscourseContext,
                 pageTitle: text,
                 uid,
                 isSamePageEnabled,
-                appendReferencedNodeToDiscourseContext,
+                appendRefNodeContext,
               });
 
               const referenceResults = isFlagEnabled("render references")


### PR DESCRIPTION
From a client request to add referenced nodes to exports.

EG: Format = [[EVD]] - {content} - {Source}
then add "Source: [[The source page title]]" to the appended Discourse Context on export

![image](https://github.com/RoamJS/query-builder/assets/3792666/3d69b8f2-19d3-4556-8b1c-95438cbfd99e)

Another workaround for `format` over `specification`, re: https://github.com/RoamJS/query-builder/issues/189 😞
