### PR TITLE
Check samepage for access-token on Authorize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/ExportGithub.tsx
+++ b/src/components/ExportGithub.tsx
@@ -209,7 +209,7 @@ export const ExportGithub = ({
 
             let attemptCount = 0;
             const check = () => {
-              if (attemptCount < 10) {
+              if (attemptCount < 30) {
                 apiPost({
                   path: "access-token",
                   domain: isDev

--- a/src/components/ExportGithub.tsx
+++ b/src/components/ExportGithub.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@blueprintjs/core";
 import nanoid from "nanoid";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+} from "react";
 import MenuItemSelect from "roamjs-components/components/MenuItemSelect";
 import apiGet from "roamjs-components/util/apiGet";
 import apiPost from "roamjs-components/util/apiPost";
@@ -51,7 +57,7 @@ export const ExportGithub = ({
   const showGitHubLogin = isGitHubAppInstalled && !gitHubAccessToken;
   const repoSelectEnabled = isGitHubAppInstalled && gitHubAccessToken;
 
-  const isDev = getNodeEnv() === "development";
+  const isDev = useMemo(() => getNodeEnv() === "development", []);
 
   const setRepo = (repo: string) => {
     setSelectedRepo(repo);


### PR DESCRIPTION
This will be used when the extension doesn't allow for a popup window to pass a `postMessage` (eg: electron apps).

Requires: https://github.com/samepage-network/samepage.network/pull/154
