### PR TITLE
add JSX and pageUid to renderToast on Export Send To

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-draggable": "^4.4.5",
         "react-in-viewport": "^1.0.0-alpha.20",
         "react-vertical-timeline-component": "^3.5.2",
-        "roamjs-components": "^0.82.13",
+        "roamjs-components": "^0.83.0",
         "signia-react": "^0.1.1"
       },
       "devDependencies": {
@@ -8147,9 +8147,9 @@
       }
     },
     "node_modules/roamjs-components": {
-      "version": "0.82.13",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.82.13.tgz",
-      "integrity": "sha512-IxQBJf2WaCAqJQf/hMbjMnEdK4fsMfHxKAIzBkqH7mz8UNYq26xqCOuTUc55Z51fAdoFiBx4AhNRLuNVqbQD0Q==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.83.0.tgz",
+      "integrity": "sha512-qULbp1F5HwRSl3FiEJKtDLqJA2T260xEzvi722bV5e9bqRfoLFE7+9jnaF26nLa0zdV+1RP6WhDo9PHxyJbLmQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@samepage/scripts": "^0.74.2",
@@ -15805,9 +15805,9 @@
       }
     },
     "roamjs-components": {
-      "version": "0.82.13",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.82.13.tgz",
-      "integrity": "sha512-IxQBJf2WaCAqJQf/hMbjMnEdK4fsMfHxKAIzBkqH7mz8UNYq26xqCOuTUc55Z51fAdoFiBx4AhNRLuNVqbQD0Q==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.83.0.tgz",
+      "integrity": "sha512-qULbp1F5HwRSl3FiEJKtDLqJA2T260xEzvi722bV5e9bqRfoLFE7+9jnaF26nLa0zdV+1RP6WhDo9PHxyJbLmQ==",
       "requires": {
         "@samepage/scripts": "^0.74.2",
         "aws-sdk-plus": "^0.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.29.1",
+      "version": "1.30.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-draggable": "^4.4.5",
     "react-in-viewport": "^1.0.0-alpha.20",
     "react-vertical-timeline-component": "^3.5.2",
-    "roamjs-components": "^0.82.13",
+    "roamjs-components": "^0.83.0",
     "signia-react": "^0.1.1"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -418,7 +418,6 @@ const ExportDialog: ExportDialogComponent = ({
             >
               [[{selectedPageTitle}]]
             </a>
-            !
           </>
         ) : (
           "Results sent!"

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -16,7 +16,7 @@ import {
   Radio,
   FormGroup,
 } from "@blueprintjs/core";
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, FormEvent } from "react";
 import MenuItemSelect from "roamjs-components/components/MenuItemSelect";
 import { saveAs } from "file-saver";
 import { Result } from "roamjs-components/types/query-builder";
@@ -97,6 +97,8 @@ const EXPORT_DESTINATIONS = [
   { id: "samepage", label: "Store with SamePage", active: false },
   { id: "github", label: "Send to GitHub", active: true },
 ];
+const SEND_TO_DESTINATIONS = ["page", "graph"];
+
 const exportDestinationById = Object.fromEntries(
   EXPORT_DESTINATIONS.map((ed) => [ed.id, ed])
 );
@@ -154,7 +156,9 @@ const ExportDialog: ExportDialogComponent = ({
   const [selectedPageTitle, setSelectedPageTitle] = useState(currentPageTitle);
   const [selectedPageUid, setSelectedPageUid] = useState(currentPageUid);
   const isCanvasPage = checkForCanvasPage(selectedPageTitle);
-  const [isSendToGraph, setIsSendToGraph] = useState(false);
+  const [activeSendToDestination, setActiveSendToDestination] =
+    useState<(typeof SEND_TO_DESTINATIONS)[number]>("page");
+  const isSendToGraph = activeSendToDestination === "graph";
   const [livePages, setLivePages] = useState<Result[]>([]);
   const [selectedTabId, setSelectedTabId] = useState("sendto");
   useEffect(() => {
@@ -390,8 +394,38 @@ const ExportDialog: ExportDialogComponent = ({
       if (isSendToGraph) addToGraphOverView();
       else if (isCanvasPage) await addToSelectedCanvas();
       else addToSelectedPage();
+
+      const selectedPageUid = getPageUidByPageTitle(selectedPageTitle);
+      const content =
+        activeSendToDestination === "page" ? (
+          <>
+            Results sent to{" "}
+            <a
+              onClick={(event) => {
+                if (event.shiftKey) {
+                  window.roamAlphaAPI.ui.rightSidebar.addWindow({
+                    window: {
+                      "block-uid": selectedPageUid,
+                      type: "outline",
+                    },
+                  });
+                } else {
+                  window.roamAlphaAPI.ui.mainWindow.openPage({
+                    page: { uid: selectedPageUid },
+                  });
+                }
+              }}
+            >
+              [[{selectedPageTitle}]]
+            </a>
+            !
+          </>
+        ) : (
+          "Results sent!"
+        );
+
       renderToast({
-        content: "Results sent!",
+        content,
         intent: "success",
         id: "query-builder-export-success",
       });
@@ -713,10 +747,11 @@ const ExportDialog: ExportDialogComponent = ({
     <>
       <div className={Classes.DIALOG_BODY}>
         <RadioGroup
-          onChange={(e: React.FormEvent<HTMLInputElement>) =>
-            setIsSendToGraph(isSendToGraph ? false : true)
-          }
-          selectedValue={isSendToGraph ? "graph" : "page"}
+          onChange={(e: FormEvent<HTMLInputElement>) => {
+            const target = e.target as HTMLInputElement;
+            setActiveSendToDestination(target.value);
+          }}
+          selectedValue={activeSendToDestination}
         >
           <Radio value="graph" label="Visualize in Graph Overview" />
           <Radio value="page" label="Send to Page" />


### PR DESCRIPTION
So the user can open the page they just sent the results to in main window or sidebar.  Or just ignore it.

Requires: https://github.com/RoamJS/roamjs-components/pull/25

https://www.loom.com/share/0025b7aeac864cadadd1fadbc73ea27c