### PR TITLE
isDiscourseNode small refactor

### DIFF
--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -210,7 +210,7 @@ For developers of other extensions who want to use the queries defined by users,
   - `uid` - `string` The reference of the primary node involved in the result.
   - `${string}-uid` - `string` If the users define selections that return intermediary nodes, the reference of those nodes will always end in `-uid` and will always be of type `string`.
   - `{string}` - `string | number | Date` All other fields returned in the result can be any of the primitive value types.
-- `isDiscourseNode` - `(uid?: string, nodes?: DiscourseNode[]) => boolean` Returns whether the input `uid` is a discourse node.
+- `isDiscourseNode` - `(uid: string) => boolean` Returns whether the input `uid` is a discourse node.
 
 ## Examples
 

--- a/src/utils/isDiscourseNode.ts
+++ b/src/utils/isDiscourseNode.ts
@@ -1,7 +1,8 @@
 import getDiscourseNodes from "./getDiscourseNodes";
 import findDiscourseNode from "./findDiscourseNode";
 
-const isDiscourseNode = (uid?: string, nodes = getDiscourseNodes()) => {
+const isDiscourseNode = (uid: string) => {
+  const nodes = getDiscourseNodes();
   const node = findDiscourseNode(uid, nodes);
   if (!node) return false;
   return node.backedBy !== "default";


### PR DESCRIPTION
- require `uid`, remove `nodes` params

What was the use case of having `nodes` as a param? @dvargas92495 
I checked all instances where we use `isDiscourseNode` and it looks like we are only using `uid` at the moment.

![image](https://github.com/RoamJS/query-builder/assets/3792666/3c5e096e-e8b0-4663-9286-c4c481ef58a7)


Related to https://github.com/RoamJS/roamjs-components/pull/26