### PR TITLE
Revert "remove min width on roam settings input elements"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.30.1",
+  "version": "1.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.30.1",
+      "version": "1.30.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.30.1",
+  "version": "1.30.0",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/DefaultFilters.tsx
+++ b/src/components/DefaultFilters.tsx
@@ -166,7 +166,7 @@ const DefaultFilters = (extensionAPI: OnloadArgs["extensionAPI"]) => () => {
           }}
         />
       ))}
-      <div className="flex justify-end items-center gap-2">
+      <div className="flex justify-between items-center gap-2">
         <InputGroup
           value={newColumn}
           onChange={(e) => setNewColumn(e.target.value)}

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,9 +199,6 @@ svg.rs-svg-container {
 .roamjs-query-column-views table.bp3-html-table td {
   vertical-align: initial;
 }
-.rm-settings .rm-extensions-settings input[type="text"] {
-  min-width: initial;
-}
 `);
   const isCanvasPage = (title: string) => {
     const canvasPageFormat =


### PR DESCRIPTION
Reverts RoamJS/query-builder#258

I rushed 258.  Not only did I merge into the wrong branch ... `.rm-settings .rm-extensions-settings input[type="text"]` would affect all extension, not just qb.  🙄