### PR TITLE
increase timeout and await setSizeandImageProps

### DIFF
--- a/src/components/TldrawCanvas.tsx
+++ b/src/components/TldrawCanvas.tsx
@@ -272,7 +272,7 @@ export const loadImage = (
 
     setTimeout(() => {
       reject(new Error("Image load timeout"));
-    }, 3000);
+    }, 5000);
 
     img.src = url;
   });
@@ -608,7 +608,7 @@ class DiscourseNodeUtil extends TLBoxUtil<DiscourseNodeShape> {
               }
 
               // Update Shape Props
-              setSizeAndImgProps({ context: this, text, uid });
+              await setSizeAndImgProps({ context: this, text, uid });
               this.updateProps(shape.id, {
                 title: text,
                 uid,


### PR DESCRIPTION
Users were getting Image fails when the node had 10+ relationships defined.

There is still a significant delay when adding these nodes that should be addressed.

When discourse queries are outsourced to SamePage, that would work.
Or we make `createExistingRelations` opt in / on demand.