### PR TITLE
Discourse Overlay no results fix (Closes #278)

### DIFF
--- a/src/components/DiscourseContext.tsx
+++ b/src/components/DiscourseContext.tsx
@@ -325,7 +325,7 @@ export const ContextContent = ({ uid, results, args }: Props) => {
       .finally(() => setLoading(false));
   }, [uid, results, setRawQueryResults, setLoading]);
   useEffect(() => {
-    if (!results) {
+    if (!queryResults.length) {
       onRefresh();
     }
   }, [onRefresh, results]);

--- a/src/components/DiscourseContext.tsx
+++ b/src/components/DiscourseContext.tsx
@@ -325,10 +325,10 @@ export const ContextContent = ({ uid, results, args }: Props) => {
       .finally(() => setLoading(false));
   }, [uid, results, setRawQueryResults, setLoading]);
   useEffect(() => {
-    if (!queryResults.length) {
+    if (!queryResults.length && loading) {
       onRefresh();
     }
-  }, [onRefresh, results]);
+  }, [onRefresh, results, loading]);
   const [tabId, setTabId] = useState(0);
   const [groupByTarget, setGroupByTarget] = useState(false);
   return queryResults.length ? (

--- a/src/components/DiscourseContextOverlay.tsx
+++ b/src/components/DiscourseContextOverlay.tsx
@@ -161,6 +161,7 @@ const DiscourseContextOverlay = ({ tag, id }: { tag: string; id: string }) => {
   }, [refresh, getInfo]);
   return (
     <Popover
+      autoFocus={false}
       content={
         <div
           className="roamjs-discourse-context-popover"


### PR DESCRIPTION
Discourse Overlay sends `results` which is an array, of `{label:string,results:[]}` so even if it's empty it won't trigger the `onRefresh()` which sets `setLoading(false)`

`!results` is still useful for `ReferenceContext` and `ResultsTable`

https://github.com/RoamJS/query-builder/blob/6675ed77bf5b456d7a5b4bb65dd658e598367a20/src/components/ReferenceContext.tsx#L77

https://github.com/RoamJS/query-builder/blob/7dd7e4da9946799e1a6cd38285920ff3c47be3c3/src/components/ResultsTable.tsx#L581
