### PR TITLE
Discourse Overlay no results fix (Closes #278)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/DiscourseContext.tsx
+++ b/src/components/DiscourseContext.tsx
@@ -327,8 +327,10 @@ export const ContextContent = ({ uid, results, args }: Props) => {
   useEffect(() => {
     if (!results) {
       onRefresh();
+    } else {
+      setLoading(false);
     }
-  }, [onRefresh, results]);
+  }, [onRefresh, results, setLoading]);
   const [tabId, setTabId] = useState(0);
   const [groupByTarget, setGroupByTarget] = useState(false);
   return queryResults.length ? (

--- a/src/components/DiscourseContextOverlay.tsx
+++ b/src/components/DiscourseContextOverlay.tsx
@@ -161,6 +161,7 @@ const DiscourseContextOverlay = ({ tag, id }: { tag: string; id: string }) => {
   }, [refresh, getInfo]);
   return (
     <Popover
+      autoFocus={false}
       content={
         <div
           className="roamjs-discourse-context-popover"


### PR DESCRIPTION
Discourse Overlay sends `results` which is an array, of `{label:string,results:[]}` so even if it's empty it won't trigger the `onRefresh()` which sets `setLoading(false)`

`!results` is still useful for `ReferenceContext` and `ResultsTable`

https://github.com/RoamJS/query-builder/blob/6675ed77bf5b456d7a5b4bb65dd658e598367a20/src/components/ReferenceContext.tsx#L77

https://github.com/RoamJS/query-builder/blob/7dd7e4da9946799e1a6cd38285920ff3c47be3c3/src/components/ResultsTable.tsx#L581
