### PR TITLE
Tldraw - handle pasted svg strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/patches/@tldraw+tldraw++@tldraw+editor+2.0.0-canary.ffda4cfb.patch
+++ b/patches/@tldraw+tldraw++@tldraw+editor+2.0.0-canary.ffda4cfb.patch
@@ -178,7 +178,7 @@ index 57cb723..4be6ebd 100644
  export * from "./app/types/event-types.mjs";
  export * from "./app/types/history-types.mjs";
 diff --git a/node_modules/@tldraw/tldraw/node_modules/@tldraw/editor/dist/esm/lib/utils/assets.mjs b/node_modules/@tldraw/tldraw/node_modules/@tldraw/editor/dist/esm/lib/utils/assets.mjs
-index bc63c45..8c97b7b 100644
+index bc63c45..221a390 100644
 --- a/node_modules/@tldraw/tldraw/node_modules/@tldraw/editor/dist/esm/lib/utils/assets.mjs
 +++ b/node_modules/@tldraw/tldraw/node_modules/@tldraw/editor/dist/esm/lib/utils/assets.mjs
 @@ -54,41 +54,70 @@ async function getResizedImageDataUrl(dataURLForImage, width, height) {
@@ -285,3 +285,27 @@ index bc63c45..8c97b7b 100644
  }
  async function getFileMetaData(file) {
    if (file.type === "image/gif") {
+@@ -287,12 +316,21 @@ async function createBookmarkShapeAtPoint(app, url, point) {
+     }
+   });
+ }
+-function createAssetShapeAtPoint(app, svgString, point) {
++async function createAssetShapeAtPoint(app, svgString, point) {
+   const svg = new DOMParser().parseFromString(svgString, "image/svg+xml").querySelector("svg");
+   if (!svg) {
+     throw new Error("No <svg/> element present");
+   }
+-  const dataUrl = getSvgAsDataUrlSync(svg);
++
++  const svgBlob = new Blob([svgString], { type: "image/svg+xml" });
++  const file = new File([svgBlob], "image.svg", { type: "image/svg+xml" });
++  
++  const url = await window.roamAlphaAPI.file.upload({
++    file,
++  });
++  // const dataUrl = getSvgAsDataUrlSync(svg);
++  const dataUrl = url.replace(/^!\[\]\(/, "").replace(/\)$/, "");
++
+   let width = parseFloat(svg.getAttribute("width") || "0");
+   let height = parseFloat(svg.getAttribute("height") || "0");
+   if (!(width && height)) {

--- a/patches/@tldraw+tldraw++@tldraw+ui+2.0.0-canary.ffda4cfb.patch
+++ b/patches/@tldraw+tldraw++@tldraw+ui+2.0.0-canary.ffda4cfb.patch
@@ -43,22 +43,3 @@ index 8c9610d..03a9b7c 100644
      },
      item.id
    );
-diff --git a/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs b/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs
-index d6b373d..af74af9 100644
---- a/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs
-+++ b/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs
-@@ -216,6 +216,14 @@ const handleHtmlString = async (app, html, point) => {
-   }
- };
- const handleTextString = async (app, text, point) => {
-+
-+  const MAX_TEXT_SIZE = 500 * 1024; // 500 KB in bytes
-+  if (text.length > MAX_TEXT_SIZE) {
-+      console.warn('Text is too large to paste:', text.length, 'bytes');
-+      pasteText(app, "Text is too large to paste", point);
-+      return;
-+    }
-+
-   const s = text.trim();
-   const tldrawContent = text.match(/<tldraw[^>]*>(.*)<\/tldraw>/)?.[1];
-   if (tldrawContent) {

--- a/patches/@tldraw+tldraw++@tldraw+ui+2.0.0-canary.ffda4cfb.patch
+++ b/patches/@tldraw+tldraw++@tldraw+ui+2.0.0-canary.ffda4cfb.patch
@@ -43,3 +43,22 @@ index 8c9610d..03a9b7c 100644
      },
      item.id
    );
+diff --git a/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs b/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs
+index d6b373d..af74af9 100644
+--- a/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs
++++ b/node_modules/@tldraw/tldraw/node_modules/@tldraw/ui/dist/esm/lib/hooks/useClipboardEvents.mjs
+@@ -216,6 +216,14 @@ const handleHtmlString = async (app, html, point) => {
+   }
+ };
+ const handleTextString = async (app, text, point) => {
++
++  const MAX_TEXT_SIZE = 500 * 1024; // 500 KB in bytes
++  if (text.length > MAX_TEXT_SIZE) {
++      console.warn('Text is too large to paste:', text.length, 'bytes');
++      pasteText(app, "Text is too large to paste", point);
++      return;
++    }
++
+   const s = text.trim();
+   const tldrawContent = text.match(/<tldraw[^>]*>(.*)<\/tldraw>/)?.[1];
+   if (tldrawContent) {


### PR DESCRIPTION
EDIT: we can just handle the pasted svg strings the same way further downstream.


--------------


Pasting files is handled here: https://github.com/RoamJS/query-builder/blob/main/patches/%40tldraw%2Btldraw%2B%2B%40tldraw%2Beditor%2B2.0.0-canary.ffda4cfb.patch

But it is still possible to `Copy as SVG`, then paste that clipboard which is potentially a very large string.  This is a quick safeguard for that.  

We will handle this properly in the 2.3.0+ upgrade.