### PR TITLE
Tldraw - grab current title on relation create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.33.2",
+      "version": "1.33.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/tldraw/Tldraw.tsx
+++ b/src/components/tldraw/Tldraw.tsx
@@ -579,12 +579,14 @@ const TldrawCanvas = ({ title }: Props) => {
                                   (t[2] === "destination" && !isOriginal)
                                     ? source
                                     : target;
-                                const { title, uid } =
+                                const { uid } =
                                   targetNode.props as DiscourseNodeShape["props"];
                                 return [
                                   t[0],
                                   isPageUid(uid) ? "has title" : "with uid",
-                                  isPageUid(uid) ? title : uid,
+                                  isPageUid(uid)
+                                    ? getPageTitleByPageUid(uid)
+                                    : uid,
                                 ];
                               }
                               return t.slice(0);


### PR DESCRIPTION
use case: node title was changed off canvas, so relation created would use old title stored in node props

This is a quick fix this specific use case, but in the tldraw upgrade we should `addPullWatch` on all node uid's to watch for title changes, and update canvas nodes accordingly.  

More discussion on that here: https://github.com/RoamJS/query-builder/issues/284