### PR TITLE
add command palette, add disable global

### DIFF
--- a/src/discourseGraphsMode.ts
+++ b/src/discourseGraphsMode.ts
@@ -727,8 +727,13 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
         key: "trigger",
         defaultValue: "\\",
       }).trim();
+
       const keydownListener = (e: KeyboardEvent) => {
         if (e.key === trigger) {
+          const disabled = args.extensionAPI.settings.get(
+            "disable-global-trigger"
+          );
+          if (!disabled) return;
           const target = e.target as HTMLElement;
           if (
             target.tagName === "TEXTAREA" &&

--- a/src/discourseGraphsMode.ts
+++ b/src/discourseGraphsMode.ts
@@ -733,7 +733,7 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
           const disabled = args.extensionAPI.settings.get(
             "disable-global-trigger"
           );
-          if (!disabled) return;
+          if (disabled) return;
           const target = e.target as HTMLElement;
           if (
             target.tagName === "TEXTAREA" &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import { fireQuerySync } from "./utils/fireQuery";
 import parseQuery from "./utils/parseQuery";
 import { render as exportRender } from "./components/Export";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
-
+import { render as renderDiscourseNodeMenu } from "./components/DiscourseNodeMenu";
 const loadedElsewhere = document.currentScript
   ? document.currentScript.getAttribute("data-source") === "discourse-graph"
   : false;
@@ -391,6 +391,15 @@ svg.rs-svg-container {
           },
         },
       },
+      {
+        id: "disable-global-trigger",
+        name: "Disable Global Node Menu Trigger",
+        action: {
+          type: "switch",
+        },
+        description:
+          "Whether to disable the global trigger for the Discourse Node Menu, found at [[roam/js/discourse-graph]], and use the custom trigger instead",
+      },
     ],
   });
   if (loadedElsewhere) {
@@ -721,7 +730,24 @@ svg.rs-svg-container {
       );
     },
   });
-
+  extensionAPI.ui.commandPalette.addCommand({
+    label: "Custom Discourse Node Menu Trigger",
+    callback: () => {
+      const currentlyEditingBlock = document.querySelector(
+        "textarea.rm-block-input"
+      ) as HTMLTextAreaElement;
+      if (!currentlyEditingBlock) {
+        renderToast({
+          id: "query-builder-create-block",
+          content: "Must be focused on a block to create a Discourse Node",
+        });
+        return;
+      }
+      renderDiscourseNodeMenu({
+        textarea: currentlyEditingBlock,
+      });
+    },
+  });
   const renderCustomBlockView = ({
     view,
     blockUid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -735,24 +735,6 @@ svg.rs-svg-container {
       );
     },
   });
-  extensionAPI.ui.commandPalette.addCommand({
-    label: "Custom Discourse Node Menu Trigger",
-    callback: () => {
-      const currentlyEditingBlock = document.querySelector(
-        "textarea.rm-block-input"
-      ) as HTMLTextAreaElement;
-      if (!currentlyEditingBlock) {
-        renderToast({
-          id: "query-builder-create-block",
-          content: "Must be focused on a block to create a Discourse Node",
-        });
-        return;
-      }
-      renderDiscourseNodeMenu({
-        textarea: currentlyEditingBlock,
-      });
-    },
-  });
   const renderCustomBlockView = ({
     view,
     blockUid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -735,6 +735,7 @@ svg.rs-svg-container {
       );
     },
   });
+
   const renderCustomBlockView = ({
     view,
     blockUid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,10 @@ import { fireQuerySync } from "./utils/fireQuery";
 import parseQuery from "./utils/parseQuery";
 import { render as exportRender } from "./components/Export";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
-import { render as renderDiscourseNodeMenu } from "./components/DiscourseNodeMenu";
+import {
+  NodeMenuTriggerComponent,
+  render as renderDiscourseNodeMenu,
+} from "./components/DiscourseNodeMenu";
 const loadedElsewhere = document.currentScript
   ? document.currentScript.getAttribute("data-source") === "discourse-graph"
   : false;
@@ -392,13 +395,15 @@ svg.rs-svg-container {
         },
       },
       {
-        id: "disable-global-trigger",
-        name: "Disable Global Node Menu Trigger",
+        id: "discourse-node-menu-trigger",
+        name: "Personal Node Menu Trigger",
         action: {
-          type: "switch",
+          type: "reactComponent",
+          component: () => NodeMenuTriggerComponent(extensionAPI),
         },
+
         description:
-          "Whether to disable the global trigger for the Discourse Node Menu, found at [[roam/js/discourse-graph]], and use the custom trigger instead",
+          "Override the global trigger for the Discourse Node Menu. Must refresh after editing.",
       },
     ],
   });


### PR DESCRIPTION
`\` is often used in LaTeX so users want the ability to disable it as the global node menu trigger.

I'd probably like to phase out the global trigger in favor of the command palette, but I worry that users will request a "modifier" free option, which I don't think the command palette supports.

https://www.loom.com/share/d1ab1bb4e75446aebdb186fe39dccf5b
