### PR TITLE
matchDiscourseNode early return for single "has title" clause

### DIFF
--- a/src/utils/matchDiscourseNode.ts
+++ b/src/utils/matchDiscourseNode.ts
@@ -18,12 +18,23 @@ const matchDiscourseNode = ({
       }
     | { uid: string }
   )) => {
+  // Handle specification with single "has title" clause
+  if (
+    specification.length === 1 &&
+    specification[0].type === "clause" &&
+    specification[0].relation === "has title"
+  ) {
+    const title =
+      "title" in rest ? rest.title : getPageTitleByPageUid(rest.uid);
+    const regex = new RegExp(specification[0].target.slice(1, -1));
+    return !specification[0].not && regex.test(title);
+  }
+
+  // Handle any other specification
   if (specification.length) {
     const where = replaceDatalogVariables(
       [{ from: text, to: "node" }],
-      specification.flatMap((c) =>
-        conditionToDatalog(c)
-      )
+      specification.flatMap((c) => conditionToDatalog(c))
     ).map((c) => compileDatalog(c, 0));
     const firstClause =
       "title" in rest
@@ -35,6 +46,8 @@ const matchDiscourseNode = ({
       `[:find ?node :where ${firstClause} ${where.join(" ")}]`
     ).length;
   }
+
+  // Fallback to format expression
   const title = "title" in rest ? rest.title : getPageTitleByPageUid(rest.uid);
   return getDiscourseNodeFormatExpression(format).test(title);
 };


### PR DESCRIPTION
https://www.loom.com/share/033f6d8d5915456c847e6d38591a148d

for single clause `has title` specification (which is the de facto standard and equivalent of `format`)

![image](https://github.com/user-attachments/assets/e55e91b7-997d-460a-81f4-0e31745b12a4)
