### PR TITLE
handle attribute URLs

### DIFF
--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -307,7 +307,7 @@ const ResultRow = ({
                 <a
                   className={"rm-page-ref"}
                   data-link-title={getPageTitleByPageUid(uid) || ""}
-                  href={getRoamUrl(uid)}
+                  href={(r[`${key}-url`] as string) || getRoamUrl(uid)}
                   onMouseDown={(e) => {
                     if (e.shiftKey) {
                       openBlockInSidebar(uid);

--- a/src/utils/predefinedSelections.ts
+++ b/src/utils/predefinedSelections.ts
@@ -117,6 +117,15 @@ const formatDate = ({
 const flatten = (blocks: PullBlock[] = []): PullBlock[] =>
   blocks.flatMap((b) => [b, ...flatten(b[":block/children"])]);
 
+const isValidUrl = (value: string): boolean => {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const getBlockAttribute = (key: string, r: PullBlock) => {
   const blocks = flatten(
     window.roamAlphaAPI.pull(
@@ -127,9 +136,12 @@ const getBlockAttribute = (key: string, r: PullBlock) => {
   const block = blocks.find((blk) =>
     (blk[":block/string"] || "").startsWith(key + "::")
   );
+  const value = (block?.[":block/string"] || "").slice(key.length + 2).trim();
+
   return {
-    "": (block?.[":block/string"] || "").slice(key.length + 2).trim(),
+    "": value,
     "-uid": block?.[":block/uid"] || "",
+    ...(isValidUrl(value) && { "-url": value }),
   };
 };
 


### PR DESCRIPTION
Added `{key}-url` to `Result` if valid `URL` (only in last selection test)

Request from Ivo via [Slack](https://roamresearch.slack.com/archives/C016N2B66JU/p1735568062452869)

> When the attribute value is a URL, how to make it work as such without using embed in the Query Builder column view?
