### PR TITLE
Fix user display name retrieval with optional chaining and filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.34.2",
+      "version": "1.34.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/utils/conditionToDatalog.ts
+++ b/src/utils/conditionToDatalog.ts
@@ -571,7 +571,8 @@ const translator: Record<string, Translator> = {
           `[:find (pull ?n [:node/title]) :where [?u :user/display-page ?n]]`
         ) as [PullBlock][]
       )
-        .map((d) => d[0][":node/title"] || "")
+        .map((d) => d[0]?.[":node/title"] || "")
+        .filter(Boolean)
         .concat(["{current user}"]),
     placeholder: "Enter the display name of any user with access to this graph",
   },
@@ -601,7 +602,8 @@ const translator: Record<string, Translator> = {
           `[:find (pull ?n [:node/title]) :where [?u :user/display-page ?n]]`
         ) as [PullBlock][]
       )
-        .map((d) => d[0][":node/title"] || "")
+        .map((d) => d[0]?.[":node/title"] || "")
+        .filter(Boolean)
         .concat(["{current user}"]),
     placeholder: "Enter the display name of any user with access to this graph",
   },


### PR DESCRIPTION
Apparently users can have no `:node/title`

![image](https://github.com/user-attachments/assets/79685740-25fc-4161-a9cf-c7d365566990)
